### PR TITLE
Fix bug with font leading to errors during make

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -297,7 +297,7 @@ int main(int argc, char **argv) {
         depth_cv = cv::Mat(depthDisplay.getHeight(), depthDisplay.getWidth(), CV_8UC4, depthDisplay.getPtr<sl::uchar1>(sl::MEM_CPU));
 
         if (printHelp) // Write help text on the image if needed
-            cv::putText(depth_cv, helpString, cv::Point(20, 20), CV_FONT_HERSHEY_SIMPLEX, 0.5, cv::Scalar(111, 111, 111, 255), 2);
+            cv::putText(depth_cv, helpString, cv::Point(20, 20), cv::FONT_HERSHEY_SIMPLEX, 0.5, cv::Scalar(111, 111, 111, 255), 2);
 
         cv::imshow("Depth", depth_cv);
         key = cv::waitKey(5);


### PR DESCRIPTION
On Nvidia Jetson Nano, I got the error "error: 'CV_FONT_HERSHEY_SIMPLEX' was not declared in the scope" during make.
Changing it to 'cv::FONT_HERSHEY_SIMPLEX' fixed it for me.